### PR TITLE
Show Error Message of Affected Source File

### DIFF
--- a/src/scount/c/statistics.c
+++ b/src/scount/c/statistics.c
@@ -26,7 +26,7 @@ static void reportFileError(
     const RcnSourceFile* file,
     const RcnCountResultGroup* result
 ) {
-    logE("The following file encountered an error: '%s'", file->path);
+    logE("An error was encountered for the following file: '%s'", file->path);
     const char* const statErr = (
         stats->state.errorMessage
         ? stats->state.errorMessage

--- a/src/scount/tests/functionality/sh/test_scount.sh
+++ b/src/scount/tests/functionality/sh/test_scount.sh
@@ -154,7 +154,7 @@ function test_scount_with_stop_on_error_option() {
   assert_stdout_is_empty;
   assert_stderr_contains "An error has occurred";
   assert_stderr_contains "Syntax error detected in source code";
-  assert_stderr_contains "The following file encountered an error:";
+  assert_stderr_contains "An error was encountered for the following file:";
   assert_stderr_contains "mixedWithSyntaxError/02_has_syntax_error.c";
 }
 


### PR DESCRIPTION
Improves the error message in `scount` to give more details.

Adds the `reportFileError()` function to log an additional error message about the source file that produced an error. This gives more information to the user when the input is a directory, as only showing an error for the given directory does not make it clear which source file produced the error specifically.
