### PR TITLE
Add Support for Reading Source Text From Standard Input

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks: '
 CheckOptions:
   readability-function-cognitive-complexity.IgnoreMacros: true
   readability-function-cognitive-complexity.Threshold: 30
-  readability-identifier-length.IgnoredVariableNames: 'ok'
+  readability-identifier-length.IgnoredVariableNames: '(ok|fd)'
+  readability-identifier-length.IgnoredParameterNames: 'fd'
   readability-magic-numbers.IgnorePowersOf2IntegerValues: true
   hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: true

--- a/man/scount.1
+++ b/man/scount.1
@@ -39,6 +39,16 @@ SZE|File size in bytes
 The path to the input file or directory to process.
 .br
 This is a mandatory argument.
+.br
+Use
+.B \-
+to read source text from standard input instead and treat it as plain text.
+Use
+.B \-.EXT
+to read source text from standard input and treat it as if it was a file with the
+specified file extension. For example,
+.B \-.java
+to treat the data provided via stdin as Java source code.
 .SH OPTIONS
 .TP
 .B \-\-annotate\-counts
@@ -98,6 +108,20 @@ Count lines in a directory tree:
 .RS
 .nf
 scount /path/to/project
+.fi
+.RE
+.TP
+Count source text of two files from standard input as plain text:
+.RS
+.nf
+cat input1.txt input2.txt | scount -
+.fi
+.RE
+.TP
+Count lines of code from standard input using an explicit language extension:
+.RS
+.nf
+scount -.java < Sample.java
 .fi
 .RE
 .TP

--- a/src/scount/CMakeLists.txt
+++ b/src/scount/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
     c/logging.c
     c/print.c
     c/statistics.c
+    c/input.c
 )
 
 target_include_directories(

--- a/src/scount/c/annotation.c
+++ b/src/scount/c/annotation.c
@@ -20,15 +20,19 @@
 ExitStatus outputAnnotatedSource(AppArgs args) {
     RcnSourceText annotatedSource = rcnMarkLogicalLinesInFile(args.inputPath);
     if (!annotatedSource.text) {
-        logE("Failed to annotate source file '%s'", args.inputPath);
-        logE(
-            "Check the logical line count of that file to try to "
-            "get more information on the error."
-        );
-        logE(
-            "Hint: Try to run the previous command "
-            "without the '--annotate-counts' option."
-        );
+        if (args.readFromStdin) {
+            logE("Failed to annotate source input from stdin.");
+        } else {
+            logE("Failed to annotate source file '%s'", args.inputPath);
+            logE(
+                "Check the logical line count of that file to try to "
+                "get more information on the error."
+            );
+            logE(
+                "Hint: Try to run the previous command "
+                "without the '--annotate-counts' option."
+            );
+        }
         return APP_EXIT_INVALID_INPUT;
     }
     logStdout(annotatedSource.text);

--- a/src/scount/c/arguments.c
+++ b/src/scount/c/arguments.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stddef.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -26,6 +27,7 @@
 AppArgs parseArgs(int argc, char** argv) {
     AppArgs args = {0};
     for (int i = 1; i < argc; ++i) {
+        const size_t argLen = strlen(argv[i]);
         if (strcmp(argv[i], "--annotate-counts") == 0) {
             args.annotateCounts = true;
         } else if (strcmp(argv[i], "--lines") == 0
@@ -46,6 +48,15 @@ AppArgs parseArgs(int argc, char** argv) {
         } else if (strcmp(argv[i], "-#") == 0) {
             args.versionShort = true;
             args.version = true;
+        } else if (strcmp(argv[i], "-") == 0
+            || (argLen > 2 && argv[i][0] == '-' && argv[i][1] == '.')) {
+            if (args.inputPath == NULL) {
+                args.readFromStdin = true;
+                args.inputPath = argv[i] + 1;
+            } else {
+                args.errorMessage = "Multiple input paths specified.";
+                break;
+            }
         } else if (argv[i][0] == '-') {
             args.indexUnknown = i;
             break;
@@ -96,6 +107,9 @@ void showHelpText(void) {
     logI("Positional Arguments:");
     logI(" ");
     logI("  <PATH>              The path to the input file or directory to process.");
+    logI("                      Use '-' to read plain text source input from stdin, or append a");
+    logI("                      file extension to indicate a specific source format or language,");
+    logI("                      e.g. '-.java' will treat the input provided by stdin as Java code.");
     logI(" ");
     logI("Options:");
     logI(" ");

--- a/src/scount/c/input.c
+++ b/src/scount/c/input.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Raven Computing
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "scount.h"
+
+// LCOV_EXCL_START
+static char* cleanup(char* tmpPath, char* tmpPathMk, int fd, FILE* tmpFile) {
+    if (tmpFile) {
+        (void) fclose(tmpFile);
+    }
+    if (fd >= 0) {
+        close(fd);
+    }
+    if (tmpPathMk) {
+        unlink(tmpPathMk);
+    }
+    if (tmpPath) {
+        free(tmpPath);
+    }
+    return NULL;
+}
+// LCOV_EXCL_STOP
+
+char* createTempInputFileFromStdin(const char* extension) {
+    const char* const prefix = "/tmp/scount-stdin-";
+    const char* const templ = "XXXXXX";
+    const char* const suffix = (
+        extension && strcmp(extension, "") != 0
+        ? extension
+        : ".txt"
+    );
+    const size_t templateLen = strlen(prefix) + strlen(templ) + strlen(suffix) + 1;
+
+    char* pathTemplate = malloc(templateLen);
+    if (!pathTemplate) {
+        return NULL; // LCOV_EXCL_LINE
+    }
+    strncpy(pathTemplate, prefix, templateLen - 1);
+    strncat(pathTemplate, templ, templateLen - strlen(pathTemplate) - 1);
+    strncat(pathTemplate, suffix, templateLen - strlen(pathTemplate) - 1);
+    pathTemplate[templateLen - 1] = '\0';
+
+    int fd = mkstemps(pathTemplate, (int) strlen(suffix));
+    if (fd < 0) {
+        return cleanup(pathTemplate, NULL, fd, NULL); // LCOV_EXCL_LINE
+    }
+    FILE* out = fdopen(fd, "wb");
+    if (!out) {
+        return cleanup(pathTemplate, pathTemplate, fd, NULL); // LCOV_EXCL_LINE
+    }
+
+    char buffer[2048];
+    while (true) {
+        const size_t readCount = fread(buffer, 1, sizeof(buffer), stdin);
+        if (readCount > 0) {
+            if (fwrite(buffer, 1, readCount, out) != readCount) {
+                return cleanup(pathTemplate, pathTemplate, fd, out); // LCOV_EXCL_LINE
+            }
+        }
+        if (readCount < sizeof(buffer)) {
+            if (ferror(stdin)) {
+                return cleanup(pathTemplate, pathTemplate, fd, out); // LCOV_EXCL_LINE
+            }
+            break;
+        }
+    }
+
+    if (fclose(out) != 0) {
+        return cleanup(pathTemplate, pathTemplate, -1, NULL); // LCOV_EXCL_LINE
+    }
+
+    return pathTemplate;
+}
+
+void removeTempInputFile(char* path) {
+    if (!path) {
+        return;
+    }
+    if (unlink(path) != 0) {
+        logW("Failed to remove temporary input file '%s'", path); // LCOV_EXCL_LINE
+    }
+    free(path);
+}

--- a/src/scount/c/input.c
+++ b/src/scount/c/input.c
@@ -18,7 +18,20 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#define TEMP_CLOSE _close
+#define TEMP_UNLINK _unlink
+#else
 #include <unistd.h>
+#define TEMP_CLOSE close
+#define TEMP_UNLINK unlink
+#endif
 
 #include "scount.h"
 
@@ -26,12 +39,13 @@
 static char* cleanup(char* tmpPath, char* tmpPathMk, int fd, FILE* tmpFile) {
     if (tmpFile) {
         (void) fclose(tmpFile);
+        fd = -1;
     }
     if (fd >= 0) {
-        close(fd);
+        TEMP_CLOSE(fd);
     }
     if (tmpPathMk) {
-        unlink(tmpPathMk);
+        TEMP_UNLINK(tmpPathMk);
     }
     if (tmpPath) {
         free(tmpPath);
@@ -40,15 +54,66 @@ static char* cleanup(char* tmpPath, char* tmpPathMk, int fd, FILE* tmpFile) {
 }
 // LCOV_EXCL_STOP
 
-char* createTempInputFileFromStdin(const char* extension) {
+#ifdef _WIN32
+
+static char* createTempFileImpl(const char* suffix, int* outFd) {
+    char tempDir[MAX_PATH + 1];
+    const DWORD tempDirLen = GetTempPathA((DWORD) sizeof(tempDir), tempDir);
+    if (tempDirLen == 0 || tempDirLen >= sizeof(tempDir)) {
+        return NULL;
+    }
+
+    for (unsigned int i = 0; i < 256; ++i) {
+        const unsigned int unique = (
+            (unsigned int) GetTickCount()
+            ^ (unsigned int) GetCurrentProcessId()
+            ^ (i * 2654435761u)  // Knuth
+        );
+        const size_t pathLen = (
+            strlen(tempDir) + strlen("scount-stdin-") + 8 + strlen(suffix) + 1
+        );
+        char* pathTemplate = malloc(pathLen);
+        if (!pathTemplate) {
+            return NULL;
+        }
+        (void) snprintf(
+            pathTemplate,
+            pathLen,
+            "%sscount-stdin-%08x%s",
+            tempDir,
+            unique,
+            suffix
+        );
+        const int fd = _open(
+            pathTemplate,
+            _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY, _S_IREAD | _S_IWRITE
+        );
+        if (fd >= 0) {
+            *outFd = fd;
+            return pathTemplate;
+        }
+
+        free(pathTemplate);
+        if (errno != EEXIST) {
+            return NULL;
+        }
+    }
+
+    return NULL;
+}
+
+static FILE* openFileImpl(int fd) {
+    return _fdopen(fd, "wb");
+}
+
+#else
+
+static char* createTempFileImpl(const char* suffix, int* outFd) {
     const char* const prefix = "/tmp/scount-stdin-";
     const char* const templ = "XXXXXX";
-    const char* const suffix = (
-        extension && strcmp(extension, "") != 0
-        ? extension
-        : ".txt"
+    const size_t templateLen = (
+        strlen(prefix) + strlen(templ) + strlen(suffix) + 1
     );
-    const size_t templateLen = strlen(prefix) + strlen(templ) + strlen(suffix) + 1;
 
     char* pathTemplate = malloc(templateLen);
     if (!pathTemplate) {
@@ -59,11 +124,36 @@ char* createTempInputFileFromStdin(const char* extension) {
     strncat(pathTemplate, suffix, templateLen - strlen(pathTemplate) - 1);
     pathTemplate[templateLen - 1] = '\0';
 
-    int fd = mkstemps(pathTemplate, (int) strlen(suffix));
-    if (fd < 0) {
+    *outFd = mkstemps(pathTemplate, (int) strlen(suffix));
+    if (*outFd < 0) {
+        free(pathTemplate);
+        return NULL; // LCOV_EXCL_LINE
+    }
+
+    return pathTemplate;
+}
+
+static FILE* openFileImpl(int fd) {
+    return fdopen(fd, "wb");
+}
+
+#endif
+
+char* createTempInputFileFromStdin(const char* extension) {
+    const char* const suffix = (
+        extension && strcmp(extension, "") != 0
+        ? extension
+        : ".txt"
+    );
+    char* pathTemplate = NULL;
+    int fd = -1;
+
+    pathTemplate = createTempFileImpl(suffix, &fd);
+    if (!pathTemplate || fd < 0) {
         return cleanup(pathTemplate, NULL, fd, NULL); // LCOV_EXCL_LINE
     }
-    FILE* out = fdopen(fd, "wb");
+
+    FILE* out = openFileImpl(fd);
     if (!out) {
         return cleanup(pathTemplate, pathTemplate, fd, NULL); // LCOV_EXCL_LINE
     }
@@ -95,7 +185,7 @@ void removeTempInputFile(char* path) {
     if (!path) {
         return;
     }
-    if (unlink(path) != 0) {
+    if (TEMP_UNLINK(path) != 0) {
         logW("Failed to remove temporary input file '%s'", path); // LCOV_EXCL_LINE
     }
     free(path);

--- a/src/scount/c/main.c
+++ b/src/scount/c/main.c
@@ -45,12 +45,22 @@ int main(int argc, char** argv) {
         }
         return APP_EXIT_INVALID_ARGUMENT;
     }
+    char* tempInputPath = NULL;
+    if (args.readFromStdin) {
+        tempInputPath = createTempInputFileFromStdin(args.inputPath);
+        if (!tempInputPath) {
+            logE("Failed to read source input from stdin.");
+            return APP_EXIT_PROG_IO_ERROR;
+        }
+        args.inputPath = tempInputPath;
+    }
     ExitStatus status = APP_EXIT_UNSPECIFIED_ERROR;
     if (args.annotateCounts) {
         status = outputAnnotatedSource(args);
     } else {
         status = outputStatistics(args);
     }
+    removeTempInputFile(tempInputPath);
     if (LOG_IO_ERROR_DETECTED) {
         status = APP_EXIT_PROG_IO_ERROR;
     }

--- a/src/scount/c/print.c
+++ b/src/scount/c/print.c
@@ -704,7 +704,7 @@ void printResultSingle(const RcnCountStatistics* stats, PrintBuffer* buffer) {
     prStr(buffer, "File: ");
     if (buffer->fileIsStdin) {
         prStr(buffer, "-  (Data from standard input treated as a .");
-        prStr(buffer, file->extension ? file->extension : ".text");
+        prStr(buffer, file->extension ? file->extension : "text");
         prStr(buffer, " file)");
     } else {
         prStr(buffer, file->name ? file->name : "(unknown)");

--- a/src/scount/c/print.c
+++ b/src/scount/c/print.c
@@ -702,7 +702,13 @@ void printResultSingle(const RcnCountStatistics* stats, PrintBuffer* buffer) {
     RcnCountResultGroup* result = &stats->count.results[0];
 
     prStr(buffer, "File: ");
-    prStr(buffer, file->name ? file->name : "(unknown)");
+    if (buffer->fileIsStdin) {
+        prStr(buffer, "-  (Data from standard input treated as a .");
+        prStr(buffer, file->extension ? file->extension : ".text");
+        prStr(buffer, " file)");
+    } else {
+        prStr(buffer, file->name ? file->name : "(unknown)");
+    }
     prChr(buffer, '\n');
     prChr(buffer, '\n');
     if (buffer->showLogicalLines) {

--- a/src/scount/c/scount.h
+++ b/src/scount/c/scount.h
@@ -166,7 +166,8 @@ ExitStatus outputAnnotatedSource(AppArgs args);
  * The path of the created file is returned as an allocated string owned by
  * the caller. Must be freed using `removeTempInputFile()`.
  *
- * @param extension The file extension to use for the temporary file.
+ * @param extension The file extension to use for the temporary file,
+ *                  with a leading dot.
  * @return Allocated path string to the created temp file, or `NULL` on error.
  */
 char* createTempInputFileFromStdin(const char* extension);

--- a/src/scount/c/scount.h
+++ b/src/scount/c/scount.h
@@ -49,6 +49,7 @@ typedef struct AppArgs {
     char* inputPath;     // The input `<PATH>` to process
     char* errorMessage;  // Error message in case of invalid input
     int indexUnknown;    // Index into `argv` when unknown arg found, or zero
+    bool readFromStdin;  // True when 'inputPath' is '-' or '-.ext'
     bool annotateCounts; // Option: `--annotate-counts`
     bool linesOnly;      // Option: `-l|--lines`
     bool stopOnError;    // Option: `--stop-on-error`
@@ -106,6 +107,7 @@ typedef struct PrintBuffer {
     bool showCharacters;
     bool showSourceSize;
     bool showWarnings;
+    bool fileIsStdin;
 } PrintBuffer;
 
 /**
@@ -157,6 +159,27 @@ ExitStatus outputStatistics(AppArgs args);
  * @return The exit status of the operation.
  */
 ExitStatus outputAnnotatedSource(AppArgs args);
+
+/**
+ * Reads all content from stdin and writes it into a temporary file.
+ *
+ * The path of the created file is returned as an allocated string owned by
+ * the caller. Must be freed using `removeTempInputFile()`.
+ *
+ * @param extension The file extension to use for the temporary file.
+ * @return Allocated path string to the created temp file, or `NULL` on error.
+ */
+char* createTempInputFileFromStdin(const char* extension);
+
+/**
+ * Removes a previously created temporary input file and frees its path.
+ *
+ * This function is best-effort for deletion and always frees the given path.
+ *
+ * @param path Allocated file path previously returned by
+ *             `createTempInputFileFromStdin()`.
+ */
+void removeTempInputFile(char* path);
 
 /**
  * Creates textual result output for processed statistics when the

--- a/src/scount/c/statistics.c
+++ b/src/scount/c/statistics.c
@@ -160,7 +160,11 @@ ExitStatus outputStatistics(AppArgs args) {
     if (stats->count.sizeProcessed == 0) {
         reportNothingWasProc(path, stats, args.readFromStdin);
         rcnFreeCountStatistics(stats);
-        return APP_EXIT_NOTHING_PROCESSED;
+        return (
+            args.readFromStdin
+            ? APP_EXIT_INVALID_ARGUMENT
+            : APP_EXIT_NOTHING_PROCESSED
+        );
     }
 
     PrintBuffer buffer = {

--- a/src/scount/c/statistics.c
+++ b/src/scount/c/statistics.c
@@ -90,9 +90,17 @@ static void reportInputVerbose(const char* path, RcnCountStatistics* stats) {
     }
 }
 
-static void reportNothingWasProc(const char* path, RcnCountStatistics* stats) {
+static void reportNothingWasProc(
+    const char* path,
+    RcnCountStatistics* stats,
+    bool readFromStdin
+) {
     if (stats->count.size == 1) {
         const RcnSourceFile* const file = &stats->count.files[0];
+        if (readFromStdin) {
+            logE("The file extension is not supported: '%s'", file->extension);
+            return;
+        }
         const bool inputIsDirectory = strcmp(path, file->path) != 0;
         logE("Scanned %s '%s'", inputIsDirectory ? "directory" : "file", path);
         logE("The file '%s' cannot be processed.", file->name);
@@ -150,7 +158,7 @@ ExitStatus outputStatistics(AppArgs args) {
     }
 
     if (stats->count.sizeProcessed == 0) {
-        reportNothingWasProc(path, stats);
+        reportNothingWasProc(path, stats, args.readFromStdin);
         rcnFreeCountStatistics(stats);
         return APP_EXIT_NOTHING_PROCESSED;
     }
@@ -160,7 +168,8 @@ ExitStatus outputStatistics(AppArgs args) {
         .showPhysicalLines = true,
         .showWords = !args.linesOnly,
         .showCharacters = !args.linesOnly,
-        .showSourceSize = !args.linesOnly
+        .showSourceSize = !args.linesOnly,
+        .fileIsStdin = args.readFromStdin
     };
 
     if (stats->count.size == 1) {

--- a/src/scount/tests/functionality/res/expected/output_stdin.txt
+++ b/src/scount/tests/functionality/res/expected/output_stdin.txt
@@ -1,0 +1,8 @@
+File: -  (Data from standard input treated as a .txt file)
+
+  Logical Lines of Code (LLC):        n/a
+  Physical Lines        (PHL):          2
+  Words                 (WRD):          2
+  Characters            (CHR):          8
+  Source Size in Bytes  (SZE):          8
+

--- a/src/scount/tests/functionality/res/expected/output_stdin_lines_only.txt
+++ b/src/scount/tests/functionality/res/expected/output_stdin_lines_only.txt
@@ -1,0 +1,5 @@
+File: -  (Data from standard input treated as a .txt file)
+
+  Logical Lines of Code (LLC):        n/a
+  Physical Lines        (PHL):          3
+

--- a/src/scount/tests/functionality/res/expected/output_stdin_with_ext.txt
+++ b/src/scount/tests/functionality/res/expected/output_stdin_with_ext.txt
@@ -1,0 +1,8 @@
+File: -  (Data from standard input treated as a .java file)
+
+  Logical Lines of Code (LLC):          3
+  Physical Lines        (PHL):         12
+  Words                 (WRD):         34
+  Characters            (CHR):        233
+  Source Size in Bytes  (SZE):        233
+

--- a/src/scount/tests/functionality/sh/driver.sh
+++ b/src/scount/tests/functionality/sh/driver.sh
@@ -166,8 +166,11 @@ function _read_file() {
 # Args:
 # $@ - The arguments forwarded to the executable.
 #
+# Stdin:
+# Optional data to be passed to the application via its stdin.
+#
 function run_app() {
-  "$TEST_TARGET_APP" $@ 1>"$TEST_TARGET_FILE_STDOUT" 2>"$TEST_TARGET_FILE_STDERR";
+  "$TEST_TARGET_APP" $@ <&0 1>"$TEST_TARGET_FILE_STDOUT" 2>"$TEST_TARGET_FILE_STDERR";
   TEST_TARGET_APP_EXIT_STATUS=$?;
 }
 

--- a/src/scount/tests/functionality/sh/test_scount.sh
+++ b/src/scount/tests/functionality/sh/test_scount.sh
@@ -45,6 +45,27 @@ function test_scount_with_relative_directory_input() {
   assert_stderr_is_empty;
 }
 
+function test_scount_reads_source_content_from_stdin() {
+  printf 'foo\nbar\n' | run_app -;
+  assert_exit_status $EXIT_SUCCESS;
+  assert_stdout_equals_file "expected/output_stdin.txt";
+  assert_stderr_is_empty;
+}
+
+function test_scount_reads_source_content_from_stdin_lines_only() {
+  printf 'foo\nbar\nbaz' | run_app --lines -;
+  assert_exit_status $EXIT_SUCCESS;
+  assert_stdout_equals_file "expected/output_stdin_lines_only.txt";
+  assert_stderr_is_empty;
+}
+
+function test_scount_reads_source_content_from_stdin_with_specified_extension() {
+  run_app -.java < "${TEST_RES_DIR}/mixed/Sample1.java";
+  assert_exit_status $EXIT_SUCCESS;
+  assert_stdout_equals_file "expected/output_stdin_with_ext.txt";
+  assert_stderr_is_empty;
+}
+
 function test_scount_prints_only_line_metrics_with_long_option() {
   run_app --lines "${TEST_PROJECT_DIR}/src/lib/tests/res/java/Sample.java";
   assert_exit_status $EXIT_SUCCESS;

--- a/src/scount/tests/functionality/sh/test_scount_invalid_input.sh
+++ b/src/scount/tests/functionality/sh/test_scount_invalid_input.sh
@@ -79,7 +79,7 @@ function test_scount_prints_error_when_annotating_invalid_source_from_stdin() {
 
 function test_scount_error_when_given_stdin_with_invalid_specified_extension() {
   run_app -.invalid < "${TEST_PROJECT_DIR}/src/scount/tests/functionality/res/mixed/Sample1.java";
-  assert_exit_status $EXIT_NOTHING_PROCESSED;
+  assert_exit_status $EXIT_INVALID_ARGUMENT;
   assert_stdout_is_empty;
   assert_stderr_equals "The file extension is not supported: 'invalid'";
 }

--- a/src/scount/tests/functionality/sh/test_scount_invalid_input.sh
+++ b/src/scount/tests/functionality/sh/test_scount_invalid_input.sh
@@ -62,3 +62,24 @@ function test_scount_prints_error_when_annotating_source_of_directory() {
   assert_stderr_contains "Failed to annotate source file";
   assert_stderr_contains "Check the logical line count";
 }
+
+function test_scount_with_multiple_path_arguments_stdin_and_file_prints_error() {
+  run_app "MyFile.txt" -;
+  assert_exit_status $EXIT_INVALID_ARGUMENT;
+  assert_stderr_equals "Multiple input paths specified.";
+  assert_stdout_is_empty;
+}
+
+function test_scount_prints_error_when_annotating_invalid_source_from_stdin() {
+  run_app --annotate-counts - <<< 'This is not valid source code';
+  assert_exit_status $EXIT_INVALID_INPUT;
+  assert_stderr_equals "Failed to annotate source input from stdin.";
+  assert_stdout_is_empty;
+}
+
+function test_scount_error_when_given_stdin_with_invalid_specified_extension() {
+  run_app -.invalid < "${TEST_PROJECT_DIR}/src/scount/tests/functionality/res/mixed/Sample1.java";
+  assert_exit_status $EXIT_NOTHING_PROCESSED;
+  assert_stdout_is_empty;
+  assert_stderr_equals "The file extension is not supported: 'invalid'";
+}

--- a/src/scount/tests/unit/c/test_parse_args.c
+++ b/src/scount/tests/unit/c/test_parse_args.c
@@ -217,6 +217,30 @@ void testStrictOptionSetsStrictTrue(void) {
     TEST_ASSERT_NULL(args.errorMessage);
 }
 
+void testStdinPathDashSetsInputPathAndValid(void) {
+    char* argv[] = { "scount", "-" };
+    int argc = (int)(sizeof(argv) / sizeof(argv[0]));
+    AppArgs args = parseArgs(argc, argv);
+    bool isValid = isInputValid(args);
+    TEST_ASSERT_TRUE(isValid);
+    TEST_ASSERT_EQUAL_STRING("", args.inputPath);
+    TEST_ASSERT_TRUE(args.readFromStdin);
+    TEST_ASSERT_NULL(args.errorMessage);
+    TEST_ASSERT_EQUAL_INT(0, args.indexUnknown);
+}
+
+void testStdinPathDashDotFileExtensionSetsInputPathAndValid(void) {
+    char* argv[] = { "scount", "-.java" };
+    int argc = (int)(sizeof(argv) / sizeof(argv[0]));
+    AppArgs args = parseArgs(argc, argv);
+    bool isValid = isInputValid(args);
+    TEST_ASSERT_TRUE(isValid);
+    TEST_ASSERT_EQUAL_STRING(".java", args.inputPath);
+    TEST_ASSERT_TRUE(args.readFromStdin);
+    TEST_ASSERT_NULL(args.errorMessage);
+    TEST_ASSERT_EQUAL_INT(0, args.indexUnknown);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testNoArgsSetsMessageNoInputAndInvalid);
@@ -234,5 +258,7 @@ int main(void) {
     RUN_TEST(testLinesLongOptionSetsLinesOnlyTrue);
     RUN_TEST(testLinesShortOptionSetsLinesOnlyTrue);
     RUN_TEST(testStrictOptionSetsStrictTrue);
+    RUN_TEST(testStdinPathDashSetsInputPathAndValid);
+    RUN_TEST(testStdinPathDashDotFileExtensionSetsInputPathAndValid);
     return UNITY_END();
 }


### PR DESCRIPTION
Adds support in `scount` to specify via the '_-_' argument that the input should not be read from a file but rather taken from standard input. By providing an explicit extension '_-.ext_', the user can further specify that the provided source input should be treated as source formatted in a specific format or programming language.
