### PR TITLE
Function to Allocate Zero-Initialized Sized Statistics

### DIFF
--- a/src/lib/c/statistics.c
+++ b/src/lib/c/statistics.c
@@ -307,6 +307,30 @@ RcnCountStatistics* rcnCreateCountStatistics(const char* path) {
     return stats;
 }
 
+RcnCountStatistics* rcnAllocCountStatistics(size_t size) {
+    RcnCountStatistics* stats = calloc(1, sizeof(RcnCountStatistics));
+    if (!stats) {
+        return NULL;
+    }
+    if (size > 0) {
+        RcnSourceFile* files = calloc(size, sizeof(RcnSourceFile));
+        if (!files) {
+            free(stats);
+            return NULL;
+        }
+        RcnCountResultGroup* group = calloc(size, sizeof(RcnCountResultGroup));
+        if (!group) {
+            free(files);
+            free(stats);
+            return NULL;
+        }
+        stats->count.files = files;
+        stats->count.results = group;
+        stats->count.size = size;
+    }
+    return stats;
+}
+
 void rcnFreeCountStatistics(RcnCountStatistics* stats) {
     if (stats) {
         if (stats->count.files) {

--- a/src/lib/c/statistics.c
+++ b/src/lib/c/statistics.c
@@ -318,14 +318,17 @@ RcnCountStatistics* rcnAllocCountStatistics(size_t size) {
             free(stats);
             return NULL;
         }
-        RcnCountResultGroup* group = calloc(size, sizeof(RcnCountResultGroup));
-        if (!group) {
+        RcnCountResultGroup* groups = calloc(
+            size,
+            sizeof(RcnCountResultGroup)
+        );
+        if (!groups) {
             free(files);
             free(stats);
             return NULL;
         }
         stats->count.files = files;
-        stats->count.results = group;
+        stats->count.results = groups;
         stats->count.size = size;
     }
     return stats;

--- a/src/lib/include/reckon/reckon.h
+++ b/src/lib/include/reckon/reckon.h
@@ -878,9 +878,36 @@ typedef struct RcnStatOptions {
 RECKON_EXPORT RcnCountStatistics* rcnCreateCountStatistics(const char* path);
 
 /**
+ * Allocates a new zero-initialized `RcnCountStatistics` struct.
+ * 
+ * The returned struct will have the given predefined size.
+ * The `RcnCountResultSet` member is preallocated to hold the specified number
+ * of entries. The `files` and `results` arrays of the contained
+ * `RcnCountResultSet` are each allocated with the given `size` and are
+ * zero-initialized. The `size` field of the `RcnCountResultSet` is set to
+ * the specified `size`. All other fields of the returned struct are
+ * zero-initialized.
+ *
+ * This function is intended for use cases where a user wants to manually
+ * populate the `files` and `results` members of a `RcnCountResultSet`
+ * without going through the file system via `rcnCreateCountStatistics()`.
+ * If `size` is zero, a zero-initialized `RcnCountStatistics` struct is
+ * returned with no arrays allocated.
+ *
+ * A user takes ownership of the returned struct and must free it with
+ * `rcnFreeCountStatistics()`.
+ *
+ * @param size The number of entries to preallocate in the `RcnCountResultSet`.
+ * @return A newly allocated `RcnCountStatistics` struct, or `NULL` on error.
+ * @since 1.5.0
+ */
+RECKON_EXPORT RcnCountStatistics* rcnAllocCountStatistics(size_t size);
+
+/**
  * Frees a previously allocated `RcnCountStatistics` struct.
  * 
- * Must have been previously allocated using `rcnCreateCountStatistics()`.
+ * Must have been previously allocated using `rcnCreateCountStatistics()`
+ * or `rcnAllocCountStatistics()`.
  *
  * @param stats The `RcnCountStatistics` struct to free. May be `NULL`.
  */

--- a/src/lib/include/reckon/reckon.h
+++ b/src/lib/include/reckon/reckon.h
@@ -907,7 +907,9 @@ RECKON_EXPORT RcnCountStatistics* rcnAllocCountStatistics(size_t size);
  * Frees a previously allocated `RcnCountStatistics` struct.
  * 
  * Must have been previously allocated using `rcnCreateCountStatistics()`
- * or `rcnAllocCountStatistics()`.
+ * or `rcnAllocCountStatistics()`. If you have allocated using
+ * `rcnAllocCountStatistics()` and are manually managing `RcnSourceFile` items
+ * yourself, then note that this function will deallocated them if non-NULL.
  *
  * @param stats The `RcnCountStatistics` struct to free. May be `NULL`.
  */

--- a/src/lib/tests/unit/c/test_statistics_creation.c
+++ b/src/lib/tests/unit/c/test_statistics_creation.c
@@ -147,11 +147,68 @@ void testCreateStatisticsWithPathToNonexistingFile(void) {
     rcnFreeCountStatistics(stats);
 }
 
+void testAllocStatisticsWithZeroSize(void) {
+    RcnCountStatistics* stats = rcnAllocCountStatistics(0);
+    TEST_ASSERT_NOT_NULL(stats);
+    assertZeroInitializedStatsOk(stats);
+    TEST_ASSERT_EQUAL_INT(0, stats->count.size);
+    TEST_ASSERT_EQUAL_INT(0, stats->count.sizeProcessed);
+    TEST_ASSERT_NULL(stats->count.files);
+    TEST_ASSERT_NULL(stats->count.results);
+    rcnFreeCountStatistics(stats);
+}
+
+void testAllocStatisticsWithSizeOne(void) {
+    RcnCountStatistics* stats = rcnAllocCountStatistics(1);
+    TEST_ASSERT_NOT_NULL(stats);
+    assertZeroInitializedStatsOk(stats);
+    TEST_ASSERT_EQUAL_INT(1, stats->count.size);
+    TEST_ASSERT_EQUAL_INT(0, stats->count.sizeProcessed);
+    TEST_ASSERT_NOT_NULL(stats->count.files);
+    TEST_ASSERT_NOT_NULL(stats->count.results);
+    RcnSourceFile* file = &stats->count.files[0];
+    TEST_ASSERT_NULL(file->path);
+    TEST_ASSERT_NULL(file->name);
+    TEST_ASSERT_NULL(file->extension);
+    TEST_ASSERT_NULL(file->content.text);
+    TEST_ASSERT_EQUAL_INT(0, file->content.size);
+    TEST_ASSERT_FALSE(file->isContentRead);
+    TEST_ASSERT_EQUAL_INT(RCN_FILE_OP_OK, file->status);
+    assertZeroInitializedResult(&stats->count.results[0]);
+    rcnFreeCountStatistics(stats);
+}
+
+void testAllocStatisticsWithLargerSize(void) {
+    const size_t size = 96;
+    RcnCountStatistics* stats = rcnAllocCountStatistics(size);
+    TEST_ASSERT_NOT_NULL(stats);
+    assertZeroInitializedStatsOk(stats);
+    TEST_ASSERT_EQUAL_INT(size, stats->count.size);
+    TEST_ASSERT_EQUAL_INT(0, stats->count.sizeProcessed);
+    TEST_ASSERT_NOT_NULL(stats->count.files);
+    TEST_ASSERT_NOT_NULL(stats->count.results);
+    for (size_t i = 0; i < size; ++i) {
+        RcnSourceFile* file = &stats->count.files[i];
+        TEST_ASSERT_NULL(file->path);
+        TEST_ASSERT_NULL(file->name);
+        TEST_ASSERT_NULL(file->extension);
+        TEST_ASSERT_NULL(file->content.text);
+        TEST_ASSERT_EQUAL_INT(0, file->content.size);
+        TEST_ASSERT_FALSE(file->isContentRead);
+        TEST_ASSERT_EQUAL_INT(RCN_FILE_OP_OK, file->status);
+        assertZeroInitializedResult(&stats->count.results[i]);
+    }
+    rcnFreeCountStatistics(stats);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testCreateStatisticsWithNullPathReturnsNull);
     RUN_TEST(testCreateStatisticsWithPathToRegularFile);
     RUN_TEST(testCreateStatisticsWithPathToDirectory);
     RUN_TEST(testCreateStatisticsWithPathToNonexistingFile);
+    RUN_TEST(testAllocStatisticsWithZeroSize);
+    RUN_TEST(testAllocStatisticsWithSizeOne);
+    RUN_TEST(testAllocStatisticsWithLargerSize);
     return UNITY_END();
 }


### PR DESCRIPTION
Adds the `rcnAllocCountStatistics()` function for zero-initialized manual allocation of a predefined size.
