### PR TITLE
Improve General Count Accuracy by Ignoring Build Files

### DIFF
--- a/src/lib/c/fileio.c
+++ b/src/lib/c/fileio.c
@@ -295,6 +295,13 @@ void freeSourceFileList(SourceFileList* list) {
     }
 }
 
+bool shouldIgnoreDirectory(const char* name) {
+    return strcmp(name, "build") == 0
+        || strcmp(name, "bin") == 0
+        || strcmp(name, "target") == 0
+        || strcmp(name, "dist") == 0;
+}
+
 bool readSourceFileContent(RcnSourceFile* file) {
     if (!file) {
         return false;

--- a/src/lib/c/fileio.h
+++ b/src/lib/c/fileio.h
@@ -176,6 +176,12 @@ SourceFileList newSourceFileList(const char* path);
 void freeSourceFileList(SourceFileList* list);
 
 /**
+ * Determines whether a directory with the given name should be ignored
+ * during directory traversal. Name must not be `NULL`.
+ */
+bool shouldIgnoreDirectory(const char* name);
+
+/**
  * Performs lightweight text format detection for a file.
  *
  * Detection currently relies solely on the file extension.

--- a/src/lib/c/linux/fileio.c
+++ b/src/lib/c/linux/fileio.c
@@ -29,6 +29,15 @@
 #include "reckon/reckon.h"
 #include "fileio.h"
 
+static bool shouldIgnoreDirectory(const char* name) {
+    return (
+        strcmp(name, "build") == 0
+        || strcmp(name, "bin") == 0
+        || strcmp(name, "target") == 0
+        || strcmp(name, "dist") == 0
+    );
+}
+
 /**
  * Constructs the full file path for a given directory entry,
  * i.e. a child in the `base` directory.
@@ -99,6 +108,10 @@ void scanDirectory(char* dirPath, DirStack* stack, SourceFileList* list) {
         if (entryIsRegularFile) {
             appendFile(list, fullPath);
         } else if (entryIsDirectory) {
+            if (shouldIgnoreDirectory(entry->d_name)) {
+                free(fullPath);
+                continue;
+            }
             dirStackPush(stack, fullPath);
             continue;
         }

--- a/src/lib/c/linux/fileio.c
+++ b/src/lib/c/linux/fileio.c
@@ -29,15 +29,6 @@
 #include "reckon/reckon.h"
 #include "fileio.h"
 
-static bool shouldIgnoreDirectory(const char* name) {
-    return (
-        strcmp(name, "build") == 0
-        || strcmp(name, "bin") == 0
-        || strcmp(name, "target") == 0
-        || strcmp(name, "dist") == 0
-    );
-}
-
 /**
  * Constructs the full file path for a given directory entry,
  * i.e. a child in the `base` directory.

--- a/src/lib/c/win32/fileio.c
+++ b/src/lib/c/win32/fileio.c
@@ -27,15 +27,6 @@
 #include "reckon/reckon.h"
 #include "fileio.h"
 
-static bool shouldIgnoreDirectory(const char* name) {
-    return (
-        strcmp(name, "build") == 0
-        || strcmp(name, "bin") == 0
-        || strcmp(name, "target") == 0
-        || strcmp(name, "dist") == 0
-    );
-}
-
 static char getPathSeparatorToUse(const char* path, size_t length) {
     for (size_t i = 0; i < length; ++i) {
         if (path[i] == '\\') {

--- a/src/lib/c/win32/fileio.c
+++ b/src/lib/c/win32/fileio.c
@@ -165,7 +165,6 @@ void scanDirectory(char* dirPath, DirStack* stack, SourceFileList* list) {
                 name
             );
         }
-        free(name);
 
         DWORD attributes = findData.dwFileAttributes;
         const bool isDirectory = (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
@@ -174,12 +173,15 @@ void scanDirectory(char* dirPath, DirStack* stack, SourceFileList* list) {
             appendFile(list, fullPath);
         } else if (isDirectory) {
             if (shouldIgnoreDirectory(name)) {
+                free(name);
                 free(fullPath);
                 continue;
             }
             dirStackPush(stack, fullPath);
+            free(name);
             continue;
         }
+        free(name);
         free(fullPath);
     } while (FindNextFileW(found, &findData));
 

--- a/src/lib/c/win32/fileio.c
+++ b/src/lib/c/win32/fileio.c
@@ -27,6 +27,15 @@
 #include "reckon/reckon.h"
 #include "fileio.h"
 
+static bool shouldIgnoreDirectory(const char* name) {
+    return (
+        strcmp(name, "build") == 0
+        || strcmp(name, "bin") == 0
+        || strcmp(name, "target") == 0
+        || strcmp(name, "dist") == 0
+    );
+}
+
 static char getPathSeparatorToUse(const char* path, size_t length) {
     for (size_t i = 0; i < length; ++i) {
         if (path[i] == '\\') {
@@ -173,6 +182,10 @@ void scanDirectory(char* dirPath, DirStack* stack, SourceFileList* list) {
         if (isRegularFile) {
             appendFile(list, fullPath);
         } else if (isDirectory) {
+            if (shouldIgnoreDirectory(name)) {
+                free(fullPath);
+                continue;
+            }
             dirStackPush(stack, fullPath);
             continue;
         }

--- a/src/lib/tests/integration/c/test_fileio.c
+++ b/src/lib/tests/integration/c/test_fileio.c
@@ -39,6 +39,9 @@
 #define PATH_SAMPLE_DIR3_FILE1 PATH_DIR_RES3 "/3" FILE_SAMPLE1
 #define PATH_SAMPLE_JAVA_FILE RECKON_TEST_PATH_RES_BASE "/java/Sample.java"
 #define PATH_SAMPLE_R_FILE RECKON_TEST_PATH_RES_BASE "/misc/sample.R"
+#define PATH_ARTIFACTS_DIR RECKON_TEST_PATH_RES_BASE "/artifacts"
+#define PATH_ARTIFACTS_SRC1_FILE PATH_ARTIFACTS_DIR "/1source.txt"
+#define PATH_ARTIFACTS_SRC2_FILE PATH_ARTIFACTS_DIR "/src/2source.txt"
 
 void setUp(void) { }
 
@@ -328,6 +331,19 @@ void testCreateSourceFileListOfDirectoryWithTrailingSlashInPath(void) {
     freeSourceFileList(&fileList);
 }
 
+void testCreateSourceFileListIgnoresArtifactDirectories(void) {
+    char* dirPath = PATH_ARTIFACTS_DIR;
+    SourceFileList fileList = newSourceFileList(dirPath);
+    TEST_ASSERT_TRUE(fileList.ok);
+    TEST_ASSERT_EQUAL_INT(2, fileList.size);
+    TEST_ASSERT_NOT_NULL(fileList.files);
+    RcnSourceFile* file1 = &fileList.files[0];
+    assertValidFileListItem(file1, "1source.txt", PATH_ARTIFACTS_SRC1_FILE);
+    RcnSourceFile* file2 = &fileList.files[1];
+    assertValidFileListItem(file2, "2source.txt", PATH_ARTIFACTS_SRC2_FILE);
+    freeSourceFileList(&fileList);
+}
+
 // NOLINTEND(readability-magic-numbers)
 
 int main(void) {
@@ -357,5 +373,6 @@ int main(void) {
     RUN_TEST(testCreateSourceFileListOfDirectoryContainingOnlyOneValidFile);
     RUN_TEST(testCreateSourceFileListOfDirectoryWithMoreSubdirectories);
     RUN_TEST(testCreateSourceFileListOfDirectoryWithTrailingSlashInPath);
+    RUN_TEST(testCreateSourceFileListIgnoresArtifactDirectories);
     return UNITY_END();
 }

--- a/src/lib/tests/res/artifacts/1source.txt
+++ b/src/lib/tests/res/artifacts/1source.txt
@@ -1,0 +1,1 @@
+Root source file that should be counted.

--- a/src/lib/tests/res/artifacts/dist/generated.txt
+++ b/src/lib/tests/res/artifacts/dist/generated.txt
@@ -1,0 +1,1 @@
+Generated file under dist directory. Should be ignored.

--- a/src/lib/tests/res/artifacts/src/2source.txt
+++ b/src/lib/tests/res/artifacts/src/2source.txt
@@ -1,0 +1,1 @@
+Nested source file that should be counted.

--- a/src/lib/tests/res/artifacts/src/target/generated.txt
+++ b/src/lib/tests/res/artifacts/src/target/generated.txt
@@ -1,0 +1,1 @@
+Generated file under nested target directory. Should be ignored.

--- a/src/lib/tests/res/artifacts/target/generated.txt
+++ b/src/lib/tests/res/artifacts/target/generated.txt
@@ -1,0 +1,1 @@
+Generated file under target directory. Should be ignored.


### PR DESCRIPTION
Changes what directories get scanned for files, specifically what directories get ignored. Previously, all directories were included in the count file set. This change adds a function in the directory scanning implementations that checks for common directory names containing build files that should be ignored. This is because directories designated for binary files and build artifacts can sometimes also contain copies of files in the source tree and automatically generated files by build-chains. Those files should not contribute to the result counts of the program.
