### PR TITLE
Improve Handling of Hidden Files

### DIFF
--- a/src/lib/c/win32/fileio.c
+++ b/src/lib/c/win32/fileio.c
@@ -170,11 +170,14 @@ void scanDirectory(char* dirPath, DirStack* stack, SourceFileList* list) {
         DWORD attributes = findData.dwFileAttributes;
         const bool isDirectory = (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
         const bool isRegularFile = isRegularFileAttr(attributes);
-        if (isRegularFile) {
-            appendFile(list, fullPath);
-        } else if (isDirectory) {
-            dirStackPush(stack, fullPath);
-            continue;
+        const bool isHidden = (attributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+        if (!isHidden) {
+            if (isRegularFile) {
+                appendFile(list, fullPath);
+            } else if (isDirectory) {
+                dirStackPush(stack, fullPath);
+                continue;
+            }
         }
         free(fullPath);
     } while (FindNextFileW(found, &findData));


### PR DESCRIPTION
On Windows, hidden files and directories should be ignored when a directory is scanned for files to be processed. This makes the behaviour to be more aligned with how it works on Linux-based systems.
