### PR TITLE
Improve Test Suite Assertion Failure Handling When Using Sanitizers

### DIFF
--- a/cmake/BuildUnity.cmake
+++ b/cmake/BuildUnity.cmake
@@ -1,1 +1,7 @@
 disable_compiler_warnings(unity)
+target_compile_definitions(unity PUBLIC UNITY_INCLUDE_CONFIG_H)
+target_include_directories(
+    unity
+    PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/lib/tests/include>"
+)

--- a/cmake/TestUtil.cmake
+++ b/cmake/TestUtil.cmake
@@ -182,6 +182,7 @@ function(add_test_suite)
         add_executable(
             ${TEST_SUITE_ARGS_TEST_SUITE_TARGET}
             ${TEST_SUITE_ARGS_TEST_SUITE_SOURCE}
+            "${CMAKE_SOURCE_DIR}/src/lib/tests/c/unity_config.c"
         )
 
         # Include source header files

--- a/src/lib/tests/c/unity_config.c
+++ b/src/lib/tests/c/unity_config.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 Raven Computing
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+
+bool RCN_ASSERTION_FAILURE_DISABLE_LSAN = false;
+
+#if defined(__has_include) && __has_include(<sanitizer/lsan_interface.h>)
+int __lsan_is_turned_off(void) { // NOLINT
+    return RCN_ASSERTION_FAILURE_DISABLE_LSAN ? 1 : 0;
+}
+#endif

--- a/src/lib/tests/include/unity_config.h
+++ b/src/lib/tests/include/unity_config.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Raven Computing
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifndef _WIN32
+
+#ifndef UNITY_EXCLUDE_SETJMP_H
+#include <setjmp.h>
+#else
+#error "Cannot use UNITY_EXCLUDE_SETJMP_H compile definition in this project"
+#endif
+
+// Global flag to track if any test has failed
+extern bool RCN_ASSERTION_FAILURE_DISABLE_LSAN;
+
+static void onUnityTestAbort(void) {
+    RCN_ASSERTION_FAILURE_DISABLE_LSAN = true;
+}
+
+#define UNITY_TEST_ABORT() \
+    do { \
+        onUnityTestAbort(); \
+        longjmp(Unity.AbortFrame, 1); \
+    } while(0)
+
+#endif


### PR DESCRIPTION
Adds a standard Unity `unity_config.h` configuration header file that defines the `UNITY_TEST_ABORT` macro. The macro simply sets a global boolean flag and continues with the default Unity behaviour when a test assertion fails.

Adds the `__lsan_is_turned_off()` ASAN hook function to check the global flag and, if set, disable LSAN for the test run.

This is so that when executing the test suite with sanitizer support enabled, regular test assertion failures are reported over memory leaks detected by ASAN. This is because a failed test assertion might result in cleanup code, usually located at the end of a test function, to not be executed, effectively triggering a spurious memory leak error.
